### PR TITLE
feat(): Extend the affected Resource to also contain object.

### DIFF
--- a/securityevent.schema.json
+++ b/securityevent.schema.json
@@ -53,8 +53,8 @@
             ]
         },
         "affectedResource": {
-            "type": ["string", "null"],
-            "description": "Unique identifier of the affected resource (e.g. ARN)"
+            "type": ["object", "string", "null"],
+            "description": "Information about the affected Resource (e.g. ARN, Resource-metadata)"
         },
         "surroundingEvents": {
             "type": "array",


### PR DESCRIPTION
This extends the field for the `affectedResource` to also accept arbitrary objects. This enables, among others, to reference the affected resources as linked in GuardDuty-Findings.