### PR TITLE
feat/add eventId as required field

### DIFF
--- a/sample.json
+++ b/sample.json
@@ -1,6 +1,7 @@
 {
-    "eventFormatVersion": "2024-02-08",
+    "eventFormatVersion": "2024-02-16",
     "createdAt": "2023-06-09T09:20:30",
+    "eventId": "bd65600d-8669-4903-8a14-af88203add38",
     "monitoringService": "Organizational Cloudtrail",
     "severity": "INFO",
     "accountId": "012345678910",

--- a/securityevent.schema.json
+++ b/securityevent.schema.json
@@ -8,6 +8,11 @@
         "eventFormatVersion": {
             "const": "2024-02-08"
         },
+        "eventId": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            "description": "Represents a unique identifier (uuid) of the alarm."
+        },
         "createdAt": {
             "type": "string",
             "pattern":"^\\d{4}-[0-1]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d(\\.\\d+)?(([+-][0-2]\\d:[0-5]\\d)|Z)?$",
@@ -92,5 +97,5 @@
             "required": ["score", "severity", "vectorString"]
         }
     },
-    "required": ["eventFormatVersion", "createdAt", "monitoringService", "severity", "confidence", "environment", "affectedResource"]
+    "required": ["eventFormatVersion", "eventId", "createdAt", "monitoringService", "severity", "confidence", "environment", "affectedResource"]
 }

--- a/securityevent.schema.json
+++ b/securityevent.schema.json
@@ -6,7 +6,7 @@
     "type": "object",
     "properties": {
         "eventFormatVersion": {
-            "const": "2024-02-08"
+            "const": "2024-02-16"
         },
         "eventId": {
             "type": "string",


### PR DESCRIPTION
This change introduces a required eventId (uuid) as part of the iris event.
Please do not merge it automatically, as other components need to have the logic of the creation of this field first.